### PR TITLE
Multitouch event fix android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
@@ -21,7 +21,7 @@ class RNGestureHandlerEnabledRootView : ReactRootView {
 
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
     try {
-      if (gestureRootHelper?.dispatchTouchEvent(ev)|| super.dispatchTouchEvent(ev)) {
+      if (gestureRootHelper?.dispatchTouchEvent(ev) || super.dispatchTouchEvent(ev)) {
         return true
       }
     } catch (e: IllegalArgumentException) {}

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
@@ -20,9 +20,13 @@ class RNGestureHandlerEnabledRootView : ReactRootView {
   }
 
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-    return if (gestureRootHelper?.dispatchTouchEvent(ev) == true) {
-      true
-    } else super.dispatchTouchEvent(ev)
+    try {
+      if (gestureRootHelper?.dispatchTouchEvent(ev)|| super.dispatchTouchEvent(ev)) {
+        return true
+      }
+    } catch (e: IllegalArgumentException) {}
+
+    return super.dispatchTouchEvent(ev)
   }
 
   /**

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
@@ -21,7 +21,7 @@ class RNGestureHandlerEnabledRootView : ReactRootView {
 
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
     try {
-      if (gestureRootHelper?.dispatchTouchEvent(ev) || super.dispatchTouchEvent(ev)) {
+      if (gestureRootHelper?.dispatchTouchEvent(ev) == true || super.dispatchTouchEvent(ev)) {
         return true
       }
     } catch (e: IllegalArgumentException) {}

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
@@ -26,7 +26,7 @@ class RNGestureHandlerEnabledRootView : ReactRootView {
       }
     } catch (e: IllegalArgumentException) {}
 
-    return super.dispatchTouchEvent(ev)
+    return false
   }
 
   /**


### PR DESCRIPTION
Workaround for the multitouch issue: `java.lang.IllegalArgumentException: pointerIndex out of range`

Solution based on:
facebook/react-native#30320