### PR TITLE
Add try catch block to prevent crash for multitouch event

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEnabledRootView.java
@@ -33,10 +33,17 @@ public class RNGestureHandlerEnabledRootView extends ReactRootView {
 
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
-    if (mGestureRootHelper != null && mGestureRootHelper.dispatchTouchEvent(ev)) {
-      return true;
+    try {
+      if (mGestureRootHelper != null && mGestureRootHelper.dispatchTouchEvent(ev)) {
+        return true;
+      }
+      if (super.dispatchTouchEvent(ev)) {
+        return true;
+      }
+    } catch (IllegalArgumentException e) {
+      e.printStackTrace();
     }
-    return super.dispatchTouchEvent(ev);
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Description

As a workaround for the multi touch crash on Android:
`java.lang.IllegalArgumentException: pointerIndex out of range` 
we need to apply the workaround solution which was proposed here:
https://github.com/facebook/react-native/issues/30320 
